### PR TITLE
Refactoring Write Repository to follow DRY principle.

### DIFF
--- a/src/POC.EntityFrameworkCore/Repositories/Orders/OrderWriteRepository.cs
+++ b/src/POC.EntityFrameworkCore/Repositories/Orders/OrderWriteRepository.cs
@@ -28,18 +28,9 @@ namespace POC.Repositories.Orders
         {
         }
 
-        public override async Task<Order> GetAsync(OrderId orderId)
+        public override Order ReHydrate(IEnumerable<EventSourcedEvent> events)
         {
-            var historyEvents =await EventStore.GetEventsAsync(orderId.Value.ToString());
-            List<EventSourcedEvent> events = [];
-            foreach (var e in historyEvents)
-            {
-                var eventType = Type.GetType(e.EventType);
-                var domainEvent = this.JsonSerializer.Deserialize(eventType, e.EventData);
-                events.Add((EventSourcedEvent)domainEvent);
-            }
-            var order = Order.Rehydrate(events);
-            return order;
+            return Order.Rehydrate(events);
         }
     }
 }

--- a/src/POC.EntityFrameworkCore/Repositories/WriteRepository.cs
+++ b/src/POC.EntityFrameworkCore/Repositories/WriteRepository.cs
@@ -30,14 +30,14 @@ namespace POC.Repositories
         public async Task<TAggregate> GetAsync(OrderId orderId)
         {
             var historyEvents = await EventStore.GetEventsAsync(orderId.Value.ToString());
-            List<EventSourcedEvent> events = [];
-            foreach (var e in historyEvents)
+            List<EventSourcedEvent> eventSourcedEvents = [];
+            foreach (var @event in historyEvents)
             {
-                var eventType = Type.GetType(e.EventType);
-                var domainEvent = this.JsonSerializer.Deserialize(eventType, e.EventData);
-                events.Add((EventSourcedEvent)domainEvent);
+                var eventType = Type.GetType(@event.EventType);
+                var domainEvent = this.JsonSerializer.Deserialize(eventType, @event.EventData);
+                eventSourcedEvents.Add((EventSourcedEvent)domainEvent);
             }
-            var agg = ReHydrate(events);
+            var agg = ReHydrate(eventSourcedEvents);
             return agg;
         }
         public async Task SaveAsync(TAggregate aggregate, CancellationToken cancellationToken)

--- a/src/POC.EntityFrameworkCore/Repositories/WriteRepository.cs
+++ b/src/POC.EntityFrameworkCore/Repositories/WriteRepository.cs
@@ -1,8 +1,11 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using POC.Abstractions;
+using POC.Orders;
 using Volo.Abp.EventBus.Local;
 using Volo.Abp.Json;
 
@@ -15,15 +18,28 @@ namespace POC.Repositories
         protected readonly ILocalEventBus EventBus;
         protected readonly IJsonSerializer JsonSerializer;
 
-        public WriteRepository(IEventStore eventStore, ILocalEventBus eventBus, IJsonSerializer jsonSerializer)
+        protected WriteRepository(IEventStore eventStore, ILocalEventBus eventBus, IJsonSerializer jsonSerializer)
         {
             EventStore = eventStore;
             EventBus = eventBus;
             JsonSerializer = jsonSerializer;
         }
 
-        public abstract Task<TAggregate> GetAsync(TId id);
+        public abstract TAggregate ReHydrate(IEnumerable<EventSourcedEvent> events);
 
+        public async Task<TAggregate> GetAsync(OrderId orderId)
+        {
+            var historyEvents = await EventStore.GetEventsAsync(orderId.Value.ToString());
+            List<EventSourcedEvent> events = [];
+            foreach (var e in historyEvents)
+            {
+                var eventType = Type.GetType(e.EventType);
+                var domainEvent = this.JsonSerializer.Deserialize(eventType, e.EventData);
+                events.Add((EventSourcedEvent)domainEvent);
+            }
+            var agg = ReHydrate(events);
+            return agg;
+        }
         public async Task SaveAsync(TAggregate aggregate, CancellationToken cancellationToken)
         {
             var events = aggregate.UncommittedEvents.Select(e => new StoredEvent


### PR DESCRIPTION
Refactoring Write Repository GetAsync MethodTo be Reusable and Reduce code in Concrete classes of Write Repositories.